### PR TITLE
add option to crop octomap

### DIFF
--- a/CMakeLists1.txt
+++ b/CMakeLists1.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(SegmentationMapping)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 SET(CMAKE_BUILD_TYPE Release)
 
 #SET(EIGEN_INCLUDE_DIR /usr/local/include/eigen3)

--- a/include/SegmentationMapping/labeled_pc_map.hpp
+++ b/include/SegmentationMapping/labeled_pc_map.hpp
@@ -531,21 +531,23 @@ namespace SegmentationMapping {
 
     if (octomap_enabled_){
       //if (is_update_occupancy)
-
-      octomap::point3d bbx_min(-bounding_box_size_, -bounding_box_size_, -bounding_box_size_);
-      octomap::point3d bbx_max(bounding_box_size_, bounding_box_size_, bounding_box_size_);
-      octomap::point3d dxyz(T_map2body_eigen(0, 3), T_map2body_eigen(1, 3), T_map2body_eigen(2, 3));
-      bbx_min = bbx_min + dxyz;
-      bbx_max = bbx_max + dxyz;
-      octree_ptr_->setBBXMin(bbx_min);
-      octree_ptr_->setBBXMax(bbx_max);
-
-      for(octomap::SemanticOcTree::leaf_iterator it = octree_ptr_->begin_leafs(),
-       end=octree_ptr_->end_leafs(); it!= end; ++it)    // loop through all leaves
+      if(bounding_box_size_ > 0)
       {
-        if (!octree_ptr_->inBBX(it.getCoordinate())){
-          // std::cout << "In BBX: " << octree_ptr_->inBBX(it.getCoordinate()) << std::endl;
-          octree_ptr_->deleteNode(it.getCoordinate());  // delete leaf if outside bounding box
+        octomap::point3d bbx_min(-bounding_box_size_, -bounding_box_size_, -bounding_box_size_);
+        octomap::point3d bbx_max(bounding_box_size_, bounding_box_size_, bounding_box_size_);
+        octomap::point3d dxyz(T_map2body_eigen(0, 3), T_map2body_eigen(1, 3), T_map2body_eigen(2, 3));
+        bbx_min = bbx_min + dxyz;
+        bbx_max = bbx_max + dxyz;
+        octree_ptr_->setBBXMin(bbx_min);
+        octree_ptr_->setBBXMax(bbx_max);
+
+        for(octomap::SemanticOcTree::leaf_iterator it = octree_ptr_->begin_leafs(),
+         end=octree_ptr_->end_leafs(); it!= end; ++it)    // loop through all leaves
+        {
+          if (!octree_ptr_->inBBX(it.getCoordinate())){
+            // std::cout << "In BBX: " << octree_ptr_->inBBX(it.getCoordinate()) << std::endl;
+            octree_ptr_->deleteNode(it.getCoordinate());  // delete leaf if outside bounding box
+          }
         }
       }
 

--- a/include/SegmentationMapping/labeled_pc_map.hpp
+++ b/include/SegmentationMapping/labeled_pc_map.hpp
@@ -86,6 +86,7 @@ namespace SegmentationMapping {
       , octomap_frame_counter_(0)
       , octomap_num_frames_(200)
       , octomap_max_dist_(20.0)
+      , bounding_box_size_(7.0)
     {
       // Parse parameters
       ros::NodeHandle pnh("~");
@@ -94,7 +95,7 @@ namespace SegmentationMapping {
       pnh.getParam("distribution_enabled", distribution_enabled_);
       pnh.getParam("body_frame", body_frame_);
       pnh.getParam("save_pcd_enabled", save_pcd_enabled_);
-      pnh.getParam( "stacking_visualization_enabled", stacking_visualization_enabled_);
+      pnh.getParam("stacking_visualization_enabled", stacking_visualization_enabled_);
       pnh.getParam("path_visualization_enabled", path_visualization_enabled_);
       pnh.getParam("color_octomap_enabled", color_octomap_enabled_);
       pnh.getParam("occupancy_grid_noise_percent", occupancy_grid_noise_percent_);
@@ -104,6 +105,7 @@ namespace SegmentationMapping {
       pnh.getParam("octomap_num_frames", octomap_num_frames_);
       pnh.getParam("octomap_max_dist", octomap_max_dist_);
       pnh.getParam("octomap_resolution", octomap_resolution_);
+      pnh.getParam("bounding_box_size", bounding_box_size_);
 
       XmlRpc::XmlRpcValue v;
       pnh.getParam("labels_to_ignore_in_map", v);
@@ -179,22 +181,22 @@ namespace SegmentationMapping {
 
 
       if (octomap_enabled_) {
-        // create label map
-        label2color[2]  =std::make_tuple(250, 250, 250 ); // road
-        //label2color[3]  =std::make_tuple(128, 64,  128 ); // sidewalk
-        label2color[3]  =std::make_tuple(250, 250,  250 ); // sidewalk
-        label2color[5]  =std::make_tuple(250, 128, 0   ); // building
-        label2color[10] =std::make_tuple(192, 192, 192 ); // pole
-        label2color[12] =std::make_tuple(250, 250, 0   ); // sign
-        label2color[6]  =std::make_tuple(0  , 100, 0   ); // vegetation
-        label2color[4]  =std::make_tuple(128, 128, 0   ); // terrain
-        label2color[13] =std::make_tuple(135, 206, 235 ); // sky
-        label2color[1]  =std::make_tuple( 30, 144, 250 ); // water
-        label2color[8]  =std::make_tuple(220, 20,  60  ); // person
-        label2color[7]  =std::make_tuple( 0, 0,142     ); // car
-        label2color[9]  =std::make_tuple(119, 11, 32   ); // bike
-        label2color[11] =std::make_tuple(123, 104, 238 ); // stair
-        label2color[0]  =std::make_tuple(255, 255, 255 ); // background
+        // // create label map
+         label2color[2]  =std::make_tuple(250, 250, 250 ); // road
+         label2color[3]  =std::make_tuple(128, 64,  128 ); // sidewalk
+         label2color[3]  =std::make_tuple(250, 250,  250 ); // sidewalk
+         label2color[5]  =std::make_tuple(250, 128, 0   ); // building
+         label2color[10] =std::make_tuple(192, 192, 192 ); // pole
+         label2color[12] =std::make_tuple(250, 250, 0   ); // sign
+         label2color[6]  =std::make_tuple(0  , 100, 0   ); // vegetation
+         label2color[4]  =std::make_tuple(128, 128, 0   ); // terrain
+         label2color[13] =std::make_tuple(135, 206, 235 ); // sky
+         label2color[1]  =std::make_tuple( 30, 144, 250 ); // water
+         label2color[8]  =std::make_tuple(220, 20,  60  ); // person
+         label2color[7]  =std::make_tuple( 0, 0,142     ); // car
+         label2color[9]  =std::make_tuple(119, 11, 32   ); // bike
+         label2color[11] =std::make_tuple(123, 104, 238 ); // stair
+         label2color[0]  =std::make_tuple(255, 255, 255 ); // background
 
 
         octree_ptr_ = std::make_shared<octomap::SemanticOcTree>(octomap::SemanticOcTree(octomap_resolution_,
@@ -207,7 +209,7 @@ namespace SegmentationMapping {
         pnh.getParam("octomap_prob_miss", prob_miss);
         octree_ptr_->setProbHit(prob_hit);
         octree_ptr_->setProbMiss(prob_miss);
-        
+        octree_ptr_->useBBXLimit(true);   // use bounding box limits
       }
       
       ROS_INFO("ros_pc_map init finish\n");
@@ -241,6 +243,7 @@ namespace SegmentationMapping {
     bool occupancy_grid_enabled_;
     bool cost_map_enabled_;
     bool octomap_enabled_;
+    double bounding_box_size_;
 
     // for voxel grid pointcloud map
     ros::Publisher stacked_pc_publisher_;
@@ -445,7 +448,6 @@ namespace SegmentationMapping {
                                                   const std::unordered_set<int> & target_labels,
                                                   nav_msgs::OccupancyGrid & occupancy_grid
                                                   ){
-    
     for (int i = 0; i < transformed_pc.size(); i++  ) {
       auto & p = transformed_pc[i];
       float x = p.x;
@@ -529,7 +531,26 @@ namespace SegmentationMapping {
 
     if (octomap_enabled_){
       //if (is_update_occupancy)
+
+      octomap::point3d bbx_min(-bounding_box_size_, -bounding_box_size_, -bounding_box_size_);
+      octomap::point3d bbx_max(bounding_box_size_, bounding_box_size_, bounding_box_size_);
+      octomap::point3d dxyz(T_map2body_eigen(0, 3), T_map2body_eigen(1, 3), T_map2body_eigen(2, 3));
+      bbx_min = bbx_min + dxyz;
+      bbx_max = bbx_max + dxyz;
+      octree_ptr_->setBBXMin(bbx_min);
+      octree_ptr_->setBBXMax(bbx_max);
+
+      for(octomap::SemanticOcTree::leaf_iterator it = octree_ptr_->begin_leafs(),
+       end=octree_ptr_->end_leafs(); it!= end; ++it)    // loop through all leaves
+      {
+        if (!octree_ptr_->inBBX(it.getCoordinate())){
+          // std::cout << "In BBX: " << octree_ptr_->inBBX(it.getCoordinate()) << std::endl;
+          octree_ptr_->deleteNode(it.getCoordinate());  // delete leaf if outside bounding box
+        }
+      }
+
       octree_ptr_->updateInnerOccupancy();
+      std::cout << "Number of leaf nodes: " << octree_ptr_->getNumLeafNodes() << std::endl;
       
       std::cout<<"publishing semantic octree\n";
       octomap_msgs::Octomap bmap_msg;
@@ -595,19 +616,15 @@ namespace SegmentationMapping {
   inline void
   PointCloudPainter<NUM_CLASS>::FuseMapIncremental(const pcl::PointCloud<pcl::PointSegmentedDistribution<NUM_CLASS>> & local_pc,
                                                    const Eigen::Affine3d & pose_at_pc){
-    
     ros::Time t = pcl_conversions::fromPCL(local_pc.header.stamp );
     std_msgs::Header header;
     header.stamp = t;
-
     pcl::PointCloud<pcl::PointSegmentedDistribution<NUM_CLASS>> transformed_pc;
     transformed_pc.header = local_pc.header;
     pcl::transformPointCloud (local_pc, transformed_pc, pose_at_pc);
-
     if (octomap_enabled_) {
       add_pc_to_octomap(transformed_pc , pose_at_pc, true, false, t );
     }
-
     if (stacking_visualization_enabled_ ) {
       header.frame_id = this->static_frame_;
       pcl_conversions::toPCL(header, pointcloud_seg_stacked_ptr_->header);
@@ -619,7 +636,6 @@ namespace SegmentationMapping {
         pcl::io::savePCDFile ("segmented_pcd_stacked/stacked_pc_distribution.pcd", *pointcloud_seg_stacked_ptr_);
 
     }
-
     if (occupancy_grid_enabled_) {
       SemanticOcTree3d_to_OccupancyGrid2d(transformed_pc, *octree_ptr_, target_labels,  *occupancy_grid_ptr_);
       std::cout << "publishing occupancy grid\n";
@@ -631,7 +647,6 @@ namespace SegmentationMapping {
       occupancy_grid_ptr_->header.stamp = t;
       occupancy_grid_publisher_.publish(*occupancy_grid_ptr_); 
     }
-
     if (cost_map_enabled_) {
       update_cost_map();
       std::cout << "publishing cost map\n";
@@ -639,24 +654,19 @@ namespace SegmentationMapping {
       cost_map_ptr_->header.stamp = t;
       cost_map_publisher_.publish(*cost_map_ptr_); 
     }
-
     ros::Time curr_t4 = ros::Time::now();
     ROS_DEBUG_STREAM("Callback ends at time "<< (uint32_t)(curr_t4.toSec()) << ". " <<(uint32_t)curr_t4.toNSec() );
     std::cout<<"\n";
-       
   }
 
   
-
+  // the function below subscribes to the pointcloud topic
   template <unsigned int NUM_CLASS>
   inline void
   PointCloudPainter<NUM_CLASS>::PointCloudCallback(const sensor_msgs::PointCloudConstPtr& cloud_msg) {
 
     ros::Time curr_t = ros::Time::now();
     ROS_DEBUG_STREAM("Callback at time "<<uint32_t(curr_t.toSec())<<". "<<uint32_t(curr_t.toNSec()) );
-
-    
-
     pcl::PointCloud<pcl::PointSegmentedDistribution<NUM_CLASS> > pointcloud_seg;
     pointcloud_seg.header.frame_id = cloud_msg->header.frame_id;
     for (int i = 0; i < cloud_msg->points.size(); ++i) {
@@ -681,7 +691,6 @@ namespace SegmentationMapping {
       if (p_seg.x * p_seg.x + p_seg.y * p_seg.y + p_seg.z * p_seg.z > octomap_max_dist_ * octomap_max_dist_ )
         continue;
 
-
       float sums = 0;
       for (int c = 0; c != NUM_CLASS; c++){
         p_seg.label_distribution[c] = cloud_msg->channels[c+7].values[i];
@@ -695,7 +704,6 @@ namespace SegmentationMapping {
    // std::string name_pcd = std::to_string(cloud_msg->header.stamp.toNSec());
     //pcl::io::savePCDFile ( name_pcd + ".pcd", pointcloud_seg);
     
-
     // fetch the tf transform at that time
     tf::StampedTransform transform;
     try{
@@ -767,7 +775,6 @@ namespace SegmentationMapping {
     // build the map incrementally
     if (distribution_enabled_)
       FuseMapIncremental(pointcloud_seg, T_map2body_eigen);
-    
   }
 
 

--- a/include/SegmentationMapping/stereo_segmentation.hpp
+++ b/include/SegmentationMapping/stereo_segmentation.hpp
@@ -50,6 +50,9 @@
 //namespace tf = tensorflow;
 //namespace tf_ops = tensorflow::ops;
 
+// Extra
+#include <typeinfo>
+
 namespace SegmentationMapping {
 
 
@@ -66,6 +69,7 @@ namespace SegmentationMapping {
       , depth_cam_topic_("/camera/aligned_depth_to_color/camera_info")
       , label_topic_("/labeled_image")
       , distribution_topic_("/distribution_image")
+      , octomap_max_dist_(20.0)
     {
       ros::NodeHandle pnh("~");
       pnh.getParam("color_topic", color_topic_);
@@ -73,6 +77,7 @@ namespace SegmentationMapping {
       pnh.getParam("depth_cam_topic", depth_cam_topic_);
       pnh.getParam("label_topic", label_topic_);
       pnh.getParam("distribution_topic", distribution_topic_);
+      pnh.getParam("octomap_max_dist", octomap_max_dist_);
 
       // init the message filter for image, depth, camera info
       color_sub_ = new message_filters::Subscriber<sensor_msgs::Image> (pnh, color_topic_, 50);
@@ -81,11 +86,11 @@ namespace SegmentationMapping {
       label_sub_ = new message_filters::Subscriber<sensor_msgs::Image> (pnh, label_topic_, 5);
       distribution_sub_ = new message_filters::Subscriber<ImageLabelDistribution> (pnh, distribution_topic_, 5);
       sync_ = new message_filters::Synchronizer<sync_pol> (sync_pol(300), *depth_sub_, *color_sub_, *depth_cam_sub_, *label_sub_, *distribution_sub_);
-      
+
       sync_->registerCallback(boost::bind(&StereoSegmentation::DepthColorCallback, this,_1, _2, _3, _4, _5));
       
-      pc1_publisher_ = pnh.advertise<sensor_msgs::PointCloud>("/labeled_pointcloud", 1);
-      pc2_publisher_ = pnh.advertise<sensor_msgs::PointCloud2>("/labeled_pointcloud_color_pc2", 1);
+      pc1_publisher_ = pnh.advertise<sensor_msgs::PointCloud>("/labeled_pointcloud", 1);              // publishing topic
+      pc2_publisher_ = pnh.advertise<sensor_msgs::PointCloud2>("/labeled_pointcloud_color_pc2", 1);   // publishing topic
 
 
       num_skip_frames = pnh.getParam("skip_every_k_frame", num_skip_frames);
@@ -103,20 +108,42 @@ namespace SegmentationMapping {
                                    output_label_tensor_name, output_distribution_tensor_name));
       ROS_DEBUG_STREAM("Init tensorflow and revoke frozen graph from "<<frozen_graph_path);
       */
-      label2color[2]  =std::make_tuple(250, 250, 250 ); // road
-      label2color[3]  =std::make_tuple(250, 250, 250 ); // sidewalk
-      label2color[5]  =std::make_tuple(250, 128, 0   ); // building
-      label2color[10] =std::make_tuple(192, 192, 192 ); // pole
-      label2color[12] =std::make_tuple(250, 250, 0   ); // sign
-      label2color[6]  =std::make_tuple(0  , 100, 0   ); // vegetation
-      label2color[4]  =std::make_tuple(128, 128, 0   ); // terrain
-      label2color[13] =std::make_tuple(135, 206, 235 ); // sky
-      label2color[1]  =std::make_tuple( 30, 144, 250 ); // water
-      label2color[8]  =std::make_tuple(220, 20,  60  ); // person
-      label2color[7]  =std::make_tuple( 0, 0,142     ); // car
-      label2color[9]  =std::make_tuple(119, 11, 32   ); // bike
-      label2color[11] =std::make_tuple(123, 104, 238 ); // stair
-      label2color[0]  =std::make_tuple(255, 255, 255 ); // background
+       label2color[2]  =std::make_tuple(250, 250, 250 ); // road
+       label2color[3]  =std::make_tuple(250, 250, 250 ); // sidewalk
+       label2color[5]  =std::make_tuple(250, 128, 0   ); // building
+       label2color[10] =std::make_tuple(192, 192, 192 ); // pole
+       label2color[12] =std::make_tuple(250, 250, 0   ); // sign
+       label2color[6]  =std::make_tuple(0  , 100, 0   ); // vegetation
+       label2color[4]  =std::make_tuple(128, 128, 0   ); // terrain
+       label2color[13] =std::make_tuple(135, 206, 235 ); // sky
+       label2color[1]  =std::make_tuple( 30, 144, 250 ); // water
+       label2color[8]  =std::make_tuple(220, 20,  60  ); // person
+       label2color[7]  =std::make_tuple( 0, 0,142     ); // car
+       label2color[9]  =std::make_tuple(119, 11, 32   ); // bike
+       label2color[11] =std::make_tuple(123, 104, 238 ); // stair
+       label2color[0]  =std::make_tuple(255, 255, 255 ); // background
+      
+      //  label2color[0] = std::make_tuple(29, 28, 33);
+      //  label2color[1] = std::make_tuple(208, 235, 160);
+      //  label2color[2] = std::make_tuple(43, 237, 21);
+      //  label2color[3] = std::make_tuple(217, 240, 17);
+      //  label2color[4] = std::make_tuple(186, 24, 65);
+      //  label2color[5] = std::make_tuple(192, 192, 192);
+      //  label2color[6] = std::make_tuple(235, 45, 98);
+      //  label2color[7] = std::make_tuple(20, 99, 143);
+      //  label2color[8] = std::make_tuple(157, 199, 194);
+      //  label2color[9] = std::make_tuple(237, 61, 55);
+      //  label2color[10] = std::make_tuple(32, 39, 232);
+      //  label2color[11] = std::make_tuple(37, 193, 245);
+      //  label2color[12] = std::make_tuple(132, 143, 127);
+      //  label2color[13] = std::make_tuple(25, 151, 209);
+      //  label2color[14] = std::make_tuple(83, 90, 169);
+      //  label2color[15] = std::make_tuple(158, 163, 62);
+      //  label2color[16] = std::make_tuple(182, 55, 127);
+      //  label2color[17] = std::make_tuple(101, 28, 173);
+      //  label2color[18] = std::make_tuple(162, 168, 104);
+      //  label2color[19] = std::make_tuple(162, 135, 176);
+      //  label2color[20] = std::make_tuple(45, 149, 238);
       
     }
     
@@ -170,6 +197,7 @@ namespace SegmentationMapping {
     int num_skip_frames;
     //std::unique_ptr<tfInference> tf_infer;
     std::unordered_map<int, std::tuple<uint8_t, uint8_t, uint8_t>> label2color;
+    float octomap_max_dist_;
   };
   
   template <unsigned int NUM_CLASS>
@@ -181,14 +209,14 @@ namespace SegmentationMapping {
                                                     const ImageLabelDistributionConstPtr & distribution_msg) {
     ros::Time curr_t = ros::Time::now();
     ROS_DEBUG_STREAM("Callback starts at time "<<uint32_t(curr_t.toSec())<<". "<<(uint32_t)curr_t.toNSec() );
-    
+
     // std::cout << "depth: " << depth_msg->header.stamp << std::endl;
     // std::cout << "color: " << color_msg->header.stamp << std::endl;
     // std::cout << "camera_info: " << camera_info_msg->header.stamp << std::endl;
     // std::cout << "labeled_msg: " << labeled_msg->header.stamp << std::endl;
     // std::cout << "distribution_msg: " << distribution_msg->header.stamp << std::endl;
 
-
+    
     // std::cout<<"DepthColorCallback: New callback"<< depth_msg->header.frame_id <<"\n";
     // Check for bad inputs
     if (depth_msg->header.frame_id != color_msg->header.frame_id) {
@@ -212,21 +240,33 @@ namespace SegmentationMapping {
     //;cv::Mat color = color_ptr->image;
     //cv::Mat depth = depth_ptr->image;
 
+    double fx = double(label_ptr->image.cols) / double(depth_ptr->image.cols);
+    double fy = double(label_ptr->image.rows) / double(depth_ptr->image.rows);
+
+    std::cout << fx << " " << fy << std::endl;
+
+    // cv::resize(color_ptr->image, color_ptr->image, cv::Size(), 0.755, 1.0, 0); // resize inter-nearest interpolation
+    // cv::resize(depth_ptr->image, depth_ptr->image, cv::Size(), 0.755, 1.0, 0); // resize inter-nearest interpolation
+  
+    cv::resize(color_ptr->image, color_ptr->image, cv::Size(), fx, fy, 0); // resize inter-nearest interpolation
+    cv::resize(depth_ptr->image, depth_ptr->image, cv::Size(), fx, fy, 0); // resize inter-nearest interpolation
+
     int rows = color_ptr->image.rows;
     int cols = color_ptr->image.cols;
     
     //float * buffer = new float [distribution_msg->distribution.data.layout.dims[0].stride];
     std::vector<float> data = distribution_msg->distribution.data;
-   
+     
     //  TensorMap<Tensor<int, 4>> t_4d(storage, 2, 4, 2, 8);
     //Eigen::Map<Eigen::MatrixXf> mat(data.data(), h, w);
     //cv::Mat distribution_output = cv::Mat(rows, cols, CV_32FC(uint32_t(distribution_msg->distribution.layout.dim[2].size)), distribution_msg->distribution.data).clone();
+
     cv::Mat distribution_output = cv::Mat(rows, cols, CV_32FC(NUM_CLASS), const_cast<float*>(distribution_msg->distribution.data.data())).clone();
     //std::cout<<"distribution.data size "<<distribution_output.total() * distribution_output.elemSize()<<std::endl;
     
     //tf_infer->segmentation(color, 20, label_output, distribution_output);
     
-      
+    
     // Update camera model
     this->model_.fromCameraInfo(camera_info_msg);
 
@@ -252,7 +292,7 @@ namespace SegmentationMapping {
                                                    const cv::Mat & label_img,
                                                    const cv::Mat & distribution_img) {
     std::cout<<"New image with label\n";
-    
+
     // Set up to-publish cloud msg
     sensor_msgs::PointCloud::Ptr cloud_msg(new sensor_msgs::PointCloud);
     cloud_msg->header = depth_msg->header;  // use depth image time stamp
@@ -282,7 +322,7 @@ namespace SegmentationMapping {
     float constant_x = unit_scaling / model_.fx();
     float constant_y = unit_scaling / model_.fy();
     float bad_point = std::numeric_limits<float>::quiet_NaN();
-  
+    
     const uint16_t* depth_row = reinterpret_cast<const uint16_t*>(&depth_msg->data[0]);
     int row_step = depth_msg->step / sizeof(uint16_t);
     const uint8_t* color = &color_msg->data[0];
@@ -320,17 +360,16 @@ namespace SegmentationMapping {
         p.x = (u - center_x) * depth * constant_x;
         p.y = (v - center_y) * depth * constant_y;
         p.z = (float) depth * unit_scaling;
-        points_count += 1;
+        points_count += 1;  // stores the total number of "good" points
       }
 
       if (depth > 0)
-      	if (sqrt(p.x * p.x + p.y * p.y + p.z * p.z) > 9)
+      	// if (sqrt(p.x * p.x + p.y * p.y + p.z * p.z) > 9)  // eliminate too far points MAGICAL NUMBER
+        if (sqrt(p.x * p.x + p.y * p.y + p.z * p.z) > octomap_max_dist_)  // eliminate too far points
           p.x = p.y = p.z = bad_point;
 
       cloud_msg->points.push_back(p);
-
       if (publish_semantic) {
-
         // Fill in semantics
         //cv::Mat dist_cv =distribution_exp(cv::Rect(u, v, 1, 1));
         cv::Vec<float, NUM_CLASS> dist_class = distribution_exp.at<cv::Vec<float, NUM_CLASS>>(v, u);
@@ -353,7 +392,7 @@ namespace SegmentationMapping {
         float sum_all_exp = dist_class.sum();
         dist_class = (dist_class / sum_all_exp).eval();
         */
-        int max_ind =0;
+        int max_ind = 0;
         float max_elem = 0;
         for (int i = 0; i < NUM_CLASS; i++) {
           if (dist_class(i) > max_elem) {
@@ -400,7 +439,6 @@ namespace SegmentationMapping {
     for (int i = 0; i < NUM_CLASS; i++)
       cloud_msg->channels.push_back(distribution_channel[i]);
 
-    
     pc1_publisher_.publish(cloud_msg);
   }
 


### PR DESCRIPTION
I only kept the code of the branch **cropping-bc-fix** ( which is derivated from **cropping** ) that creates the rolling octomap.

bounding_box_size is the parameter used to set the size of the rolling octomap. Use a negative value to keep the entire map.
@tejaswid 